### PR TITLE
Fix #eliminate_byebug

### DIFF
--- a/lib/make_it_so/rails/app_builder.rb
+++ b/lib/make_it_so/rails/app_builder.rb
@@ -32,7 +32,8 @@ module MakeItSo
       end
 
       def eliminate_byebug
-        gsub_file 'Gemfile', /gem '|"byebug'|"/, ''
+        both_lines = /^[[:space:]]*# Call 'byebug'.*gem 'byebug'.*?$\n/m
+        gsub_file 'Gemfile', both_lines, "\n"
       end
 
       def rspec_dependency

--- a/spec/features/user_generates_rails_spec.rb
+++ b/spec/features/user_generates_rails_spec.rb
@@ -36,6 +36,16 @@ feature 'user generates rails app' do
     expect(File.read(app_layout)).to include('flash')
   end
 
+  scenario 'creates a valid gemfile' do
+    words = ['source', '#', 'gem', 'group', 'end']
+
+    File.readlines('Gemfile').each do |line|
+      unless line.strip.empty?
+        expect(line.strip.start_with?(*words)).to eq(true)
+      end
+    end
+  end
+
   context 'pry-rails' do
     it 'is added as a dependency' do
       expect(File.read(gemfile_path)).to match(/gem(.*)pry-rails/)
@@ -51,11 +61,13 @@ feature 'user generates rails app' do
       spec_helper = join_paths(app_path, 'spec/spec_helper.rb')
       expect(FileTest.exists?(spec_helper)).to eq(true)
     end
+
     context 'byebug' do
-      it 'comments out the byebug dependency' do
+      it 'removes the byebug dependency' do
         expect(File.read(gemfile_path)).to_not match(/gem(.*)byebug/)
       end
     end
+
     context 'capybara' do
       it 'includes capybara as a Gemfile dependency' do
         expect(File.read(gemfile_path)).to include('capybara')


### PR DESCRIPTION
- Fix regex in `eliminate_byebug` so that it doesn't remove `gem '` from all the other gems. 
- Make it remove the comment for byebug, too.
- Add test to guard against this issue in the future.