### PR TITLE
Database cleaner

### DIFF
--- a/lib/generators/rails_app_generator.rb
+++ b/lib/generators/rails_app_generator.rb
@@ -77,6 +77,7 @@ module MakeItSo
         build 'rspec_dependency'
         #build 'fix_generators'
         build 'factory_bot_rspec'
+        build 'database_cleaner_rspec'
         build 'valid_attribute_rspec'
         build 'shoulda_rspec'
       end

--- a/lib/make_it_so/rails/app_builder.rb
+++ b/lib/make_it_so/rails/app_builder.rb
@@ -130,6 +130,17 @@ module MakeItSo
         end
       end
 
+      def database_cleaner_rspec
+        self.gem 'database_cleaner', group: [:development, :test]
+        after_bundle do
+          inside 'spec' do
+            inside 'support' do
+              template 'database_cleaner.rb'
+            end
+          end
+        end
+      end
+
       def valid_attribute_rspec
         self.gem 'valid_attribute', group: [:development, :test]
         after_bundle do

--- a/spec/features/user_generates_rails_spec.rb
+++ b/spec/features/user_generates_rails_spec.rb
@@ -131,6 +131,17 @@ feature 'user generates rails app' do
           to include("require 'shoulda-matchers'")
       end
     end
+
+    context 'database_cleaner' do
+      it 'includes database_cleaner in the gemfile' do
+        expect(File.read(gemfile_path)).to include('database_cleaner')
+      end
+
+      it 'creates the database_cleaner support file' do
+        support_path = join_paths(app_path, 'spec/support/database_cleaner.rb')
+        expect(FileTest.exists?(support_path)).to eq(true)
+      end
+    end
   end
 
   context 'devise' do

--- a/templates/rails/spec/support/database_cleaner.rb
+++ b/templates/rails/spec/support/database_cleaner.rb
@@ -1,0 +1,25 @@
+RSpec.configure do |config|
+
+  # before each test suite, dump the database completely
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  # “sets the default database cleaning strategy to be transactions”
+  #
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
Since database_cleaner is such a great help whenever running repeated test suites, I thought it might be nice if it were included in our `make_it_so rails` gem.  I have it set to be in the `group[:development, :test]` but we might only need it in `:test` - I can certainly change it if you would prefer it to be only in the `:test` group in the Gemfile.