### PR TITLE
Fix duplicate enzyme config

### DIFF
--- a/lib/make_it_so/rails/app_builder.rb
+++ b/lib/make_it_so/rails/app_builder.rb
@@ -78,14 +78,11 @@ module MakeItSo
 
       def karma
         after_bundle do
-          run 'mkdir -p spec/javascript/support'
-          inside 'spec/javascript/support' do
-            template 'enzyme.js'
-          end
-
           add_test_dependency_snippets(
             ["js_karma_jasmine_testing_deps.json", "js_enzyme_testing_deps.json"]
           )
+
+          create_enzyme_config
 
           template 'karma.conf.js'
           inside 'spec/javascript' do
@@ -104,14 +101,11 @@ module MakeItSo
 
       def jest
         after_bundle do
-          run 'mkdir -p spec/javascript/support'
-          inside 'spec/javascript/support' do
-            template 'enzyme.js'
-          end
-
           add_test_dependency_snippets(
             ["js_jest_testing_deps.json", "js_enzyme_testing_deps.json"]
           )
+
+          create_enzyme_config
 
           remove_file '.babelrc'
           template '.babelrc'
@@ -283,6 +277,17 @@ module MakeItSo
               json[key].merge!(parsed_snippet[key])
             end
           end
+        end
+      end
+
+      def create_enzyme_config 
+        run 'mkdir -p spec/javascript/support'
+        devDependencies = parsed_package_json["devDependencies"].keys
+        enzymeAdapter = devDependencies.select{ |d| d =~ /^enzyme-adapter-react-[0-9]*/ }[0]
+
+        inside 'spec/javascript/support' do
+          template 'enzyme.js'
+          gsub_file 'enzyme.js', 'ADAPTER NAME GOES HERE', enzymeAdapter
         end
       end
 

--- a/lib/make_it_so/rails/app_builder.rb
+++ b/lib/make_it_so/rails/app_builder.rb
@@ -81,6 +81,11 @@ module MakeItSo
           unparsed_json = snippet('js_karma_jasmine_testing_deps.json')
           parsed_json = JSON.parse(unparsed_json)
 
+          run 'mkdir -p spec/javascript/support'
+          inside 'spec/javascript/support' do
+            template 'enzyme.js'
+          end
+
           modify_json(package_json_file) do |json|
             json["devDependencies"] ||= {}
             json["devDependencies"].merge!(parsed_json["devDependencies"])

--- a/snippets/rails/js_enzyme_testing_deps.json
+++ b/snippets/rails/js_enzyme_testing_deps.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "enzyme": "~3.10.0",
+    "enzyme-adapter-react-16": "~1.14.0"
+  }
+}

--- a/snippets/rails/js_jest_testing_deps.json
+++ b/snippets/rails/js_jest_testing_deps.json
@@ -1,9 +1,26 @@
 {
   "devDependencies": {
     "babel-jest": "~23.4.0",
-    "enzyme": "~3.10.0",
-    "enzyme-adapter-react-16": "~1.14.0",
     "fetch-mock": "~5.13.1",
     "jest": "~23.4.1"
+  },
+  "scripts": {
+    "start": "./bin/webpack-dev-server",
+    "test": "node_modules/.bin/jest",
+    "test:dev": "node_modules/.bin/jest --notify --watch"
+  },
+  "jest": {
+    "automock": false,
+    "roots": [
+      "spec/javascript"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "app/javascript"
+    ],
+    "setupFiles": [
+      "./spec/javascript/support/enzyme.js"
+    ],
+    "testURL": "http://localhost/"
   }
 }

--- a/snippets/rails/js_karma_jasmine_testing_deps.json
+++ b/snippets/rails/js_karma_jasmine_testing_deps.json
@@ -1,7 +1,5 @@
 {
   "devDependencies": {
-    "enzyme": "~3.10.0",
-    "enzyme-adapter-react-16": "^1.14.0",
     "fetch-mock": "5",
     "fetch-ponyfill": "^6.0.2",
     "jasmine-core": "~2.4.1",
@@ -14,5 +12,8 @@
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "2.0.1",
     "phantomjs-prebuilt": "~2.1.14"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/karma start karma.conf.js"
   }
 }

--- a/spec/features/rails/user_generates_rails_spec.rb
+++ b/spec/features/rails/user_generates_rails_spec.rb
@@ -287,10 +287,11 @@ feature 'user generates rails app with default settings' do
     end
 
     it 'includes enzyme.js with correct Enzyme config' do
-      support_file = File.join(app_path, 'spec/javascript/support/enzyme.js')
+      file_subpath = "spec/javascript/support/enzyme.js"
+      support_file = File.join(app_path, file_subpath)
       expect(FileTest.exists?(support_file)).to eq(true)
 
-      enzyme = read_file(support_file)
+      enzyme = read_file(file_subpath)
       expect(enzyme).to include("Enzyme.configure")
       expect(enzyme).to include("enzyme-adapter-react-16")
     end

--- a/spec/features/rails/user_generates_rails_spec.rb
+++ b/spec/features/rails/user_generates_rails_spec.rb
@@ -286,9 +286,13 @@ feature 'user generates rails app with default settings' do
       end
     end
 
-    it 'adds a spec/javascript/support/enzyme.js file' do
+    it 'includes enzyme.js with correct Enzyme config' do
       support_file = File.join(app_path, 'spec/javascript/support/enzyme.js')
       expect(FileTest.exists?(support_file)).to eq(true)
+
+      enzyme = read_file(support_file)
+      expect(enzyme).to include("Enzyme.configure")
+      expect(enzyme).to include("enzyme-adapter-react-16")
     end
 
     it 'adds spec/javascript/support/enzyme.js to setup' do

--- a/spec/features/rails/user_generates_rails_spec.rb
+++ b/spec/features/rails/user_generates_rails_spec.rb
@@ -292,6 +292,7 @@ feature 'user generates rails app with default settings' do
       expect(FileTest.exists?(support_file)).to eq(true)
 
       enzyme = read_file(file_subpath)
+      expect(enzyme).to include('require("enzyme-adapter-react-16")')
       expect(enzyme).to include("Enzyme.configure")
       expect(enzyme).to include("enzyme-adapter-react-16")
     end

--- a/spec/features/rails/user_generates_rails_with_karma_spec.rb
+++ b/spec/features/rails/user_generates_rails_with_karma_spec.rb
@@ -41,9 +41,19 @@ feature "user generates rails app with karma/jasmine" do
     expect(read_file('.gitignore')).to include("coverage/*\n")
   end
 
-  it 'configures enzyme with adapter in testHelper' do
+  it 'does not configure enzyme adapter in testHelper' do
     testHelper = read_file('spec/javascript/testHelper.js')
-    expect(testHelper).to include("Enzyme.configure({ adapter: new EnzymeAdapter() })")
+    expect(testHelper).to_not include("Enzyme.configure({ adapter: new EnzymeAdapter() })")
+  end
+
+  it 'includes enzyme.js with correct Enzyme config' do
+    file_subpath = "spec/javascript/support/enzyme.js"
+    support_file = File.join(app_path, file_subpath)
+    expect(FileTest.exists?(support_file)).to eq(true)
+
+    enzyme = read_file(file_subpath)
+    expect(enzyme).to include("Enzyme.configure")
+    expect(enzyme).to include("enzyme-adapter-react-16")
   end
 
   it 'karma.conf.js uses @babel/polyfill' do

--- a/templates/rails/spec/javascript/support/enzyme.js
+++ b/templates/rails/spec/javascript/support/enzyme.js
@@ -1,4 +1,4 @@
 const Enzyme = require('enzyme');
-const EnzymeAdapter = require('enzyme-adapter-react-15.4');
+const EnzymeAdapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({ adapter: new EnzymeAdapter() });

--- a/templates/rails/spec/javascript/support/enzyme.js
+++ b/templates/rails/spec/javascript/support/enzyme.js
@@ -1,4 +1,4 @@
 const Enzyme = require('enzyme');
-const EnzymeAdapter = require('enzyme-adapter-react-16');
+const EnzymeAdapter = require("ADAPTER NAME GOES HERE");
 
 Enzyme.configure({ adapter: new EnzymeAdapter() });

--- a/templates/rails/spec/javascript/testHelper.js
+++ b/templates/rails/spec/javascript/testHelper.js
@@ -1,7 +1,3 @@
-const Enzyme = require('enzyme');
-const EnzymeAdapter = require('enzyme-adapter-react-16');
-Enzyme.configure({ adapter: new EnzymeAdapter() });
-
 import { shallow, mount } from 'enzyme';
 import jasmineEnzyme from 'jasmine-enzyme';
 import React from 'react';


### PR DESCRIPTION
* Ensure karma config creates enzyme.js
* Remove enzyme config from testHelper (should load from enzyme.js instead)
* Expand test coverage to cover issue

Additional changes:
* Refactor approach to adding test framework dependencies to package.json to more easily accommodate multiple snippets and top-level keys beyond `devDependencies`
* Pull enzyme adapter name from package.json 