### PR TITLE
include shoulda config in rails_helper

### DIFF
--- a/lib/make_it_so/rails/app_builder.rb
+++ b/lib/make_it_so/rails/app_builder.rb
@@ -200,8 +200,16 @@ module MakeItSo
           group: [:development, :test],
           require: false
         after_bundle do
-          inside 'spec/support' do
-            template 'shoulda.rb'
+          inside 'spec' do
+            insert_into_file 'rails_helper.rb',
+              after: rails_helper_insertion_hook do
+
+              "require File.join(File.dirname(__FILE__), 'support/shoulda')\n"
+            end
+
+            inside 'support' do
+              template 'shoulda.rb'
+            end
           end
         end
       end

--- a/spec/features/rails/user_generates_rails_spec.rb
+++ b/spec/features/rails/user_generates_rails_spec.rb
@@ -135,6 +135,11 @@ feature 'user generates rails app with default settings' do
       it 'includes a shoulda file in the support directory' do
         expect(FileTest.exists?(join_paths(app_path, 'spec/support/shoulda.rb')))
       end
+
+      it 'requires the shoulda support file' do
+        expect(File.read(rails_spec_helper)).
+          to include("\nrequire File.join(File.dirname(__FILE__), 'support/shoulda')\n")
+      end
     end
 
     context 'database_cleaner' do


### PR DESCRIPTION
The shoulda.rb support was not required in rails_helper, which led to most students abandoning it. This PR adds a `require` line for `support/shoulda.rb` in `rails_helper`.