### PR TITLE
Updated readme to add yarn install and bundle exec instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ make_it_so rails <app_name>
 Then run:
 
 ```ruby
-rake db:create
-rake db:migrate
+yarn install
+bundle exec rake db:create
+bundle exec rake db:migrate
 ```
 
 By default, the generator will create a Rails app with the following options activated:


### PR DESCRIPTION
1. Before being able to create the database, a user needs to run `yarn install`. Added this to the rails readme instructions
2. Updated `rake db:create` and `rake db:migrate` to read `bundle exec` before both commands in the readme