### PR TITLE
Rails 6 upgrades (do not merge)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 require_relative 'lib/make_it_so/rails'
 
-ruby '2.7.3'
+ruby '3.0.2'
 
 # Specify your gem's dependencies in make_it_so.gemspec
 gemspec

--- a/lib/generators/rails_app_generator.rb
+++ b/lib/generators/rails_app_generator.rb
@@ -80,6 +80,7 @@ module MakeItSo
       build 'pry_rails_dependency'
       build 'base_stylesheets'
       build 'eliminate_byebug'
+      build 'base_config_manifest'
       unless options[:skip_javascript]
         build 'base_javascripts'
       end

--- a/lib/generators/rails_app_generator.rb
+++ b/lib/generators/rails_app_generator.rb
@@ -76,6 +76,7 @@ module MakeItSo
     def finish_template
       super
 
+      build 'change_ruby_version'
       build 'pry_rails_dependency'
       build 'base_stylesheets'
       build 'eliminate_byebug'

--- a/lib/make_it_so/rails.rb
+++ b/lib/make_it_so/rails.rb
@@ -1,5 +1,5 @@
 module MakeItSo
   module Rails
-    VERSION="5.2.5"
+    VERSION="6.1.4"
   end
 end

--- a/lib/make_it_so/rails/app_builder.rb
+++ b/lib/make_it_so/rails/app_builder.rb
@@ -47,6 +47,13 @@ module MakeItSo
         gsub_file 'Gemfile', both_lines, "\n"
       end
 
+      def change_ruby_version
+        # @generator.gem 'pg', '3.8.2', group: [:development, :test]
+
+        default_ruby_version = /^ruby '2.6.5'$/
+        gsub_file 'Gemfile', default_ruby_version, "\n"
+      end
+
       def react
         @generator.gem 'webpacker', '~> 3.3'
 

--- a/lib/make_it_so/rails/app_builder.rb
+++ b/lib/make_it_so/rails/app_builder.rb
@@ -16,8 +16,18 @@ module MakeItSo
         end
       end
 
+      def base_config_manifest
+        # new sprockets pattern for assets with sprockets 4 in Rails 6
+        empty_directory "app/assets/config"
+         inside 'app/assets/config' do
+          template 'manifest.js'
+        end
+      end
+
       def base_javascripts
         @generator.gem 'jquery-rails'
+        
+        empty_directory "app/assets/javascripts"
         inside 'app/assets/javascripts' do
           template 'application.js'
           jquery_files = "//= require jquery\n" +
@@ -55,7 +65,7 @@ module MakeItSo
       end
 
       def react
-        @generator.gem 'webpacker', '~> 3.3'
+        # @generator.gem 'webpacker', '~> 3.3'
 
         after_bundle do
           rake 'webpacker:install'
@@ -280,8 +290,6 @@ module MakeItSo
           # foundation-rails generates an application layout so we
           # must remove it
           remove_file 'app/views/layouts/foundation.html.erb'
-
-
         end
       end
 

--- a/lib/make_it_so/version.rb
+++ b/lib/make_it_so/version.rb
@@ -1,3 +1,3 @@
 module MakeItSo
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/make_it_so.gemspec
+++ b/make_it_so.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor"
-  spec.add_dependency "railties", "~> 5.2"
-  spec.add_dependency "activerecord", "~> 5.2"
+  spec.add_dependency "railties", "~> 6.1.4"
+  spec.add_dependency "activerecord", "~> 6.1.4"
   spec.add_dependency "json"
 
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/templates/rails/app/assets/config/manifest.js
+++ b/templates/rails/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../stylesheets .css
+//= link_directory ../javascripts .js


### PR DESCRIPTION
Existing work done in order to upgrade make_it_so generator to Rails 6

Unfortunately, the architecture of a Rails 6 app is different enough that I am putting this on pause

Things to investigate prior to continuing
- investigate using webpacker as new asset pipeline manager over sprockets, and what changes will be needed accordingly
- figure out if we want sprockets-rails 4 or to just leave it off and have all assets managed by webpacker 
- work with consulting team on babel/webpack configuration to update the config that we add with make_it_so (we might be able to remove much of our old patterns now that webpacker comes standard with Rails 6)

And while we are at it
- remove shoulda configuration
- remove enzyme/karma configuration 